### PR TITLE
ci: configs iniciais de CI para rodar testes

### DIFF
--- a/.github/workflows/run-tests-on-pr.yaml
+++ b/.github/workflows/run-tests-on-pr.yaml
@@ -1,0 +1,16 @@
+name: rodar testes em PRs
+on:
+  push:
+    branches-ignore:
+      - main
+  # pull_request:
+  #   types: [ opened, synchronize ]
+  #   branches:
+  #     - main
+jobs:
+  run-compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build and run docker compose
+        run: docker-compose up test

--- a/.github/workflows/run-tests-on-pr.yaml
+++ b/.github/workflows/run-tests-on-pr.yaml
@@ -1,12 +1,12 @@
 name: rodar testes em PRs
 on:
-  push:
-    branches-ignore:
-      - main
-  # pull_request:
-  #   types: [ opened, synchronize ]
-  #   branches:
+  # push:
+  #   branches-ignore:
   #     - main
+  pull_request:
+    types: [ opened, synchronize ]
+    branches:
+      - main
 jobs:
   run-compose:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ Para executar em ambiente de desenvolvimento:
 * Entre no diretório local onde o repositório foi clonado;
 * Utilize o comando `sudo docker-compose up dev` para "build" e subir o servidor local e expor a porta 3000 em `localhost`. Além de `dev` também subirá o serviço `db` com o banco de dados de desenvolvimento.
 
-> **IMPORTANTE:** Esta API está programada para ser acessada a partir de `http://localhost:3000`. Certifique-se de que não existem outros recursos ocupando a porta `3000` antes de subir o projeto.
+**IMPORTANTE:** Esta API está programada para ser acessada a partir de `http://localhost:3000` e o banco de dados utiliza a porta `3306`. Certifique-se de que não existam outros recursos ocupando as portas `3000` e `3306` antes de subir o projeto.
+
+Para derrubar os serviços, execute o comando `docker-compose down`.
 
 ## Endpoints
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config = {
   verbose: true,
   coverageDirectory: "coverage",
   coveragePathIgnorePatterns: ["/node_modules/", "/dist/", "/docs/"],
+  testPathIgnorePatterns: ["/node_modules/", "/dist/", "/docs/"],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "scripts": {
     "prepare": "husky install",
     "commit": "git-cz",
-    "build": "npx tsc",
+    "build": "npx tsc --project tsconfig.build.json",
     "start": "node dist/index.js",
-    "dev": "concurrently \"npx tsc --watch\" \"nodemon -q dist/index.js\"",
+    "dev": "concurrently \"yarn run build --watch\" \"nodemon -q dist/index.js\"",
     "lint": "eslint . --ext .ts",
     "test": "jest --coverage"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ dotenv.config();
 
 const database = new DataBaseConfig({
     database: process.env.DB_NAME ?? "projeto",
-    host: process.env.DB_HOST ?? "fiap-soat-project_db",
+    host: process.env.DB_HOST ?? "localhost",
     userName: process.env.DB_USERNAME ?? "root",
     password: process.env.DB_PASSWORD ?? "testtest",
     port: 3306,

--- a/src/tests/api/produto.test.ts
+++ b/src/tests/api/produto.test.ts
@@ -1,0 +1,5 @@
+describe("Test Example", () => {
+  it("should be true", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
Add workflow básico de CI para executar os testes a partir do container `test`.
O job está configurado para rodar apenas em PRs feitos para `main`.

**Obs:** Não tenho privilégios no repo para fazer as configurações de segurança necessárias na branch (só permitir merge do PR se o CI passar, etc). Acho que tem que ser feito pelo @diorgeneseugenio.
