### PR TITLE
feat: possibilidade de criar usuarios anonimos

### DIFF
--- a/src/core/applications/services/usuarioService.ts
+++ b/src/core/applications/services/usuarioService.ts
@@ -8,20 +8,26 @@ export default class UsuarioService {
     constructor(private readonly usuarioRepository: usuarioRepository) { }
 
     async criaUsuario(usuario: Usuario) {
-        if (usuario.cpf) {
-            const cpfValidado = new CPF(usuario.cpf);
-            usuario.cpf = cpfValidado.retornaValor();
-        }
+        if (!usuario.cpf && !usuario.email) {
+            if (!usuario.nome) {
+                usuario.nome = 'Anonimo'
+            }
+        } else {
+            if (usuario.cpf) {
+                const cpfValidado = new CPF(usuario.cpf);
+                usuario.cpf = cpfValidado.retornaValor();
+            }
 
-        if (usuario.email) {
-            const emailValidado = new Email(usuario.email);
-            usuario.email = emailValidado.retornaValor();
-        }
+            if (usuario.email) {
+                const emailValidado = new Email(usuario.email);
+                usuario.email = emailValidado.retornaValor();
+            }
 
-        const usuarioExistente = await this.usuarioRepository.filtraUsuario(usuario.cpf ?? null, usuario.email ?? null);
+            const usuarioExistente = await this.usuarioRepository.filtraUsuario(usuario.cpf ?? null, usuario.email ?? null);
 
-        if (usuarioExistente) {
-            throw new Error("Usuario já existe");
+            if (usuarioExistente) {
+                throw new Error("Usuario já existe");
+            }
         }
 
         return this.usuarioRepository.criaUsuario(usuario);


### PR DESCRIPTION
Mudei a API de usuário para criar sem utilizar e-mail e/ou CPF.

Caso a pessoa não quera se identificar ela pode colocar qualquer coisa no campo nome apenas para definir como deve ser chamada, caso ela não coloque um nome no banco ficara como Anonimo.

Acredito que com isso finaliza a parte de usuários da primeira fase